### PR TITLE
Proposal: Mod Events

### DIFF
--- a/LaunchPadBooster/Events/ModEvent.cs
+++ b/LaunchPadBooster/Events/ModEvent.cs
@@ -1,0 +1,7 @@
+﻿
+namespace LaunchPadBooster.Events
+{
+  internal interface IModEvent {}
+
+  public abstract class ModEvent : IModEvent {}
+}

--- a/LaunchPadBooster/Events/ModEventPatches.cs
+++ b/LaunchPadBooster/Events/ModEventPatches.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+using System;
+
+namespace LaunchPadBooster.Events
+{
+  static class ModEventPatches
+  {
+    public static event Action<string> OnMenuPageEnabled;
+    public static event Action<string> OnMenuPageDisabled;
+
+    [HarmonyPatch(typeof(MainMenuWindowManager), nameof(MainMenuWindowManager.EnableMainMenuPage)), HarmonyPostfix]
+    public static void MainMenuWindowManager_EnableMainMenuPage(ref MainMenuWindowManager __instance, string windowName)
+    {
+      OnMenuPageEnabled?.Invoke(windowName);
+    }
+
+    [HarmonyPatch(typeof(MainMenuWindowManager), nameof(MainMenuWindowManager.DisableMainMenuPage)), HarmonyPostfix]
+    public static void MainMenuWindowManager_DisableMainMenuPage(ref MainMenuWindowManager __instance, string windowName)
+    {
+      OnMenuPageDisabled?.Invoke(windowName);
+    }
+  }
+}

--- a/LaunchPadBooster/Events/ModEvents.cs
+++ b/LaunchPadBooster/Events/ModEvents.cs
@@ -1,0 +1,87 @@
+﻿using UnityEngine.SceneManagement;
+
+namespace LaunchPadBooster.Events
+{
+  // Base Scene Events
+
+  public class SceneEvent : ModEvent
+  {
+    public Scene Scene;
+    public string Name => Scene.name;
+    public string Path => Scene.path;
+
+    public bool IsLoaded => Scene.isLoaded;
+    public bool IsSubscene => Scene.isSubScene;
+    public bool IsValid => Scene.IsValid();
+  }
+
+  public class SceneLoadEvent : SceneEvent
+  {
+    public LoadSceneMode LoadSceneMode;
+    public bool IsSingle => LoadSceneMode == LoadSceneMode.Single;
+    public bool IsAdditive => LoadSceneMode == LoadSceneMode.Additive;
+
+    public void UnloadAsync() => SceneManager.UnloadSceneAsync(Scene);
+  }
+
+  public class SceneUnloadEvent : SceneEvent {}
+
+  // Specific Scene Events
+
+  public class SplashSceneLoadEvent : SceneLoadEvent { }
+  public class SplashSceneUnloadEvent : SceneUnloadEvent { }
+
+  public class BaseSceneLoadEvent : SceneLoadEvent { }
+  public class BaseSceneUnloadEvent : SceneUnloadEvent { }
+
+  public class CharacterCutomizationSceneLoadEvent : SceneLoadEvent { }
+  public class CharacterCutomizationSceneUnloadEvent : SceneUnloadEvent { }
+
+
+  // Base Menu Page Events
+
+  public class MenuPageEvent : ModEvent
+  {
+    public string Name;
+    public virtual bool Open => false;
+  }
+
+  public class MenuPageOpenedEvent : MenuPageEvent
+  {
+    public override bool Open => true;
+  }
+
+  public class MenuPageClosedEvent : MenuPageEvent
+  {
+    public override bool Open => false;
+  }
+
+  // Menu Page Events
+
+  public class MainMenuOpenedEvent : MenuPageOpenedEvent {}
+  public class MainMenuClosedEvent : MenuPageClosedEvent {}
+
+  public class NewGameMenuOpenedEvent : MenuPageOpenedEvent {}
+  public class NewGameMenuClosedEvent : MenuPageClosedEvent {}
+
+  public class LoadGameMenuOpenedEvent : MenuPageOpenedEvent {}
+  public class LoadGameMenuClosedEvent : MenuPageClosedEvent {}
+
+  public class DifficultyMenuOpenedEvent : MenuPageOpenedEvent {}
+  public class DifficultyMenuClosedEvent : MenuPageClosedEvent {}
+
+  public class StartConditionsMenuOpenedEvent : MenuPageOpenedEvent {}
+  public class StartConditionsMenuClosedEvent : MenuPageClosedEvent {}
+
+  public class TutorialsMenuOpenedEvent : MenuPageOpenedEvent {}
+  public class TutorialsMenuClosedEvent : MenuPageClosedEvent {}
+
+  public class MultiplayerMenuOpenedEvent : MenuPageOpenedEvent {}
+  public class MultiplayerMenuClosedEvent : MenuPageClosedEvent {}
+
+  public class WorkshopMenuOpenedEvent : MenuPageOpenedEvent {}
+  public class WorkshopMenuClosedEvent : MenuPageClosedEvent {}
+
+  public class SettingsMenuOpenedEvent : MenuPageOpenedEvent {}
+  public class SettingsMenuClosedEvent : MenuPageClosedEvent {}
+}

--- a/LaunchPadBooster/Mod.cs
+++ b/LaunchPadBooster/Mod.cs
@@ -1,9 +1,13 @@
+using Assets.Scripts.Networking;
+using Assets.Scripts.Objects;
+using LaunchPadBooster.Events;
+using LaunchPadBooster.Networking;
+using LaunchPadBooster.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Assets.Scripts.Objects;
-using LaunchPadBooster.Networking;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace LaunchPadBooster
 {
@@ -22,11 +26,16 @@ namespace LaunchPadBooster
     internal readonly List<IPrefabSetup> Setups = new();
     internal readonly List<Type> SaveDataTypes = new();
 
+    public event Action<ModEvent> OnEvent;
+
     public Mod(string name, string version)
     {
       this.ID = new(name, version);
 
-      lock (allLock) AllMods.Add(this);
+      lock (allLock)
+        AllMods.Add(this);
+
+      this.RegisterEvents();
     }
 
     public void SetVersionCheck(Func<string, bool> versionCheck)
@@ -46,20 +55,25 @@ namespace LaunchPadBooster
       return version == this.ID.Version;
     }
 
+    public void AddSaveDataType(Type type)
+    {
+      this.SaveDataTypes.Add(type);
+    }
+
     public void AddSaveDataType<T>()
     {
-      this.SaveDataTypes.Add(typeof(T));
+      this.AddSaveDataType(typeof(T));
     }
 
     public void RegisterNetworkMessage<T>() where T : ModNetworkMessage<T>, new()
     {
-      SetMultiplayerRequired();
+      this.SetMultiplayerRequired();
       this.NetworkMessageTypes.Add(typeof(T));
     }
 
     public void AddPrefabs(IEnumerable<GameObject> prefabs)
     {
-      SetMultiplayerRequired();
+      this.SetMultiplayerRequired();
       PrefabPatch.Initialize();
       this.Prefabs.AddRange(prefabs.Select(prefab => prefab.GetComponent<Thing>()).Where(thing => thing != null));
     }
@@ -71,7 +85,76 @@ namespace LaunchPadBooster
       return setup;
     }
 
-    public PrefabSetup<Thing> SetupPrefabs(string name = null) => SetupPrefabs<Thing>(name);
+    public PrefabSetup<Thing> SetupPrefabs(string name = null) => this.SetupPrefabs<Thing>(name);
+
+    internal void RegisterEvents()
+    {
+      ModEventPatches.OnMenuPageEnabled += this.ModEventPatches_OnMenuPageEnabled;
+      ModEventPatches.OnMenuPageDisabled += this.ModEventPatches_OnMenuPageDisabled;
+      SceneManager.sceneLoaded += this.SceneManager_sceneLoaded;
+      SceneManager.sceneUnloaded += this.SceneManager_sceneUnloaded;
+    }
+
+    private void ModEventPatches_OnMenuPageEnabled(string page)
+    {
+
+      MenuPageOpenedEvent pageEvent = page switch
+      {
+        Constants.MAIN_MENU_PAGE => new MainMenuOpenedEvent { Name = page },
+        Constants.NEW_GAME_PAGE => new NewGameMenuOpenedEvent { Name = page },
+        Constants.LOAD_GAME_PAGE => new LoadGameMenuOpenedEvent { Name = page },
+        Constants.DIFFICULTY_SELECTION_PAGE => new DifficultyMenuOpenedEvent { Name = page },
+        Constants.STARTING_CONDITIONS_PAGE => new StartConditionsMenuOpenedEvent { Name = page },
+        Constants.TUTORIALS_PAGE => new TutorialsMenuOpenedEvent { Name = page },
+        Constants.MULTIPLAYER_PAGE => new MultiplayerMenuOpenedEvent { Name = page },
+        Constants.WORKSHOP_PAGE => new WorkshopMenuOpenedEvent { Name = page },
+        Constants.SETTINGS_PAGE => new SettingsMenuOpenedEvent { Name = page },
+        _ => throw new NotImplementedException(),
+      };
+      this.OnEvent?.Invoke(pageEvent);
+    }
+
+    private void ModEventPatches_OnMenuPageDisabled(string page)
+    {
+      MenuPageClosedEvent pageEvent = page switch
+      {
+        Constants.MAIN_MENU_PAGE => new MainMenuClosedEvent { Name = page },
+        Constants.NEW_GAME_PAGE => new NewGameMenuClosedEvent { Name = page },
+        Constants.LOAD_GAME_PAGE => new LoadGameMenuClosedEvent { Name = page },
+        Constants.DIFFICULTY_SELECTION_PAGE => new DifficultyMenuClosedEvent { Name = page },
+        Constants.STARTING_CONDITIONS_PAGE => new StartConditionsMenuClosedEvent { Name = page },
+        Constants.TUTORIALS_PAGE => new TutorialsMenuClosedEvent { Name = page },
+        Constants.MULTIPLAYER_PAGE => new MultiplayerMenuClosedEvent { Name = page },
+        Constants.WORKSHOP_PAGE => new WorkshopMenuClosedEvent { Name = page },
+        Constants.SETTINGS_PAGE => new SettingsMenuClosedEvent { Name = page },
+        _ => throw new NotImplementedException(),
+      };
+      this.OnEvent?.Invoke(pageEvent);
+    }
+
+    private void SceneManager_sceneLoaded(Scene scene, LoadSceneMode loadSceneMode)
+    {
+      SceneLoadEvent specificEvent = scene.name switch
+      {
+        Constants.SPLASH_SCENE_NAME => new SplashSceneLoadEvent() { Scene = scene, LoadSceneMode = loadSceneMode },
+        Constants.BASE_SCENE_NAME => new BaseSceneLoadEvent() { Scene = scene, LoadSceneMode = loadSceneMode },
+        Constants.CHARACTER_CUSTOMIZATION_SCENE_NAME => new CharacterCutomizationSceneLoadEvent() { Scene = scene, LoadSceneMode = loadSceneMode },
+        _ => throw new NotImplementedException(),
+      };
+      this.OnEvent?.Invoke(specificEvent);
+    }
+
+    private void SceneManager_sceneUnloaded(Scene scene)
+    {
+      SceneUnloadEvent specificEvent = scene.name switch
+      {
+        Constants.SPLASH_SCENE_NAME => new SplashSceneUnloadEvent() { Scene = scene },
+        Constants.BASE_SCENE_NAME => new BaseSceneUnloadEvent() { Scene = scene },
+        Constants.CHARACTER_CUSTOMIZATION_SCENE_NAME => new CharacterCutomizationSceneUnloadEvent() { Scene = scene },
+        _ => throw new NotImplementedException(),
+      };
+      this.OnEvent?.Invoke(specificEvent);
+    }
   }
 
   public readonly struct ModID

--- a/LaunchPadBooster/Utils/Constants.cs
+++ b/LaunchPadBooster/Utils/Constants.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.IO;
+
+namespace LaunchPadBooster.Utils
+{
+  public static class Constants
+  {
+    // FILE PATHS
+    public static string DOCUMENTS_FOLDER => Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+    public static string MY_GAMES_FOLDER => Path.Combine(DOCUMENTS_FOLDER, "My Games");
+    public static string STATIONEERS_DOCUMENTS_FOLDER => Path.Combine(MY_GAMES_FOLDER, "Stationeers");
+
+    // FILE NAMES
+    public const string CLIENT_EXECUTABLE_NAME = "rocketstation.exe";
+    public const string HEADLESS_EXECUTABLE_NAME = "rocketstation_DedicatedServer.exe";
+
+    // SCENE NAMES
+    public const string BASE_SCENE_NAME = "Base";
+    public const string SPLASH_SCENE_NAME = "Splash";
+    public const string CHARACTER_CUSTOMIZATION_SCENE_NAME = "CharacterCustomisation";
+
+    // MENU PAGE NAMES
+    public const string MAIN_MENU_PAGE = "MainMenu";
+    public const string NEW_GAME_PAGE = "NewGame";
+    public const string LOAD_GAME_PAGE = "LoadSave";
+    public const string DIFFICULTY_SELECTION_PAGE = "WorldConfiguration";
+    public const string STARTING_CONDITIONS_PAGE = "StartingConditions";
+    public const string TUTORIALS_PAGE = "TutorialScenarios";
+    public const string MULTIPLAYER_PAGE = "JoinServer";
+    public const string WORKSHOP_PAGE = "WorkshopMods";
+    public const string SETTINGS_PAGE = "Settings";
+
+    public const string DEGREE_SYMBOL = "°";
+
+    // UNITS
+    public const string FAHRENHEIT_SYMBOL = "°F";
+    public const string CELCIUS_SYMBOL = "°C";
+    public const string KELVIN_SYMBOL = "°K";
+
+    public const string PASCAL_SYMBOL = "Pa";
+    public const string KILOPASCAL_SYMBOL = "kPa";
+    public const string POUNDS_PER_SQUARE_INCH_SYMBOL = "psi";
+    public const string BAR_SYMBOL = "bar";
+    public const string TORR_SYMBOL = "torr";
+
+    public const string LITER_SYMBOL = "L";
+    public const string GALLON_SYMBOL = "gal";
+
+    public const string METERS_PER_SECOND_SYMBOL = "m/s";
+    public const string FEET_PER_SECOND_SYMBOL = "ft/s";
+    public const string KNOT_SYMBOL = "kn";
+
+    public const string JOULE_SYMBOL = "J";
+    public const string FOOTPOUND_SYMBOL = "ftlb";
+    public const string CALORIE_SYMBOL = "cal";
+
+    // ENERGY: KW
+    public const float ONE_KILOWATT = 1000f;
+    public const float TWO_KILOWATTS = ONE_KILOWATT * 2f;
+    public const float TWO_POINT_FIVE_KILOWATTS = ONE_KILOWATT * 2.5f;
+    public const float FIVE_KILOWATTS = ONE_KILOWATT * 5f;
+    public const float EIGHT_KILOWATTS = ONE_KILOWATT * 8f;
+    public const float TEN_KILOWATTS = ONE_KILOWATT * 10f;
+    public const float TWENTY_KILOWATTS = ONE_KILOWATT * 20f;
+    public const float TWENTY_FIVE_KILOWATTS = ONE_KILOWATT * 25f;
+    public const float FIFTY_KILOWATTS = ONE_KILOWATT * 50f;
+    public const float SEVENTY_FIVE_KILOWATTS = ONE_KILOWATT * 75f;
+    public const float ONE_HUNDRED_KILOWATTS = ONE_KILOWATT * 100f;
+    public const float ONE_HUNDRED_ONE_KILOWATTS = ONE_KILOWATT * 101f;
+
+    // TEMPERATURE: CELCIUS
+    public const float ABSOLUTE_ZERO_CELCIUS = -273.15f;
+    public const float ZERO_CELCIUS = 0f;
+    public const float ONE_CELCIUS = 1f;
+    public const float FIVE_CELCIUS = 5f;
+
+    public const float TEN_CELCIUS = 10f;
+    public const float FIFTEEN_CELCIUS = 15f;
+
+    public const float TWENTY_CELCIUS = 20f;
+    public const float TWENTY_FIVE_CELCIUS = 25f;
+
+    public const float THIRTY_CELCIUS = 30f;
+    public const float THIRTY_FIVE_CELCIUS = 35f;
+
+    public const float FOURTY_CELCIUS = 40f;
+    public const float FOURTY_FIVE_CELCIUS = 45f;
+
+    public const float FIFTY_CELCIUS = 50f;
+
+    public const float MINIMUM_SAFE_CELCIUS = ZERO_CELCIUS;
+    public const float MAXIMUM_SAFE_CELCIUS = FIFTY_CELCIUS;
+
+    public const float MINIMUM_CELCIUS = -272.15f;
+    public const float MAXIMUM_CELCIUS = 79726.85f;
+
+    // TEMPERATURE: KELVIN
+    public const float ABSOLUTE_ZERO_KELVIN = 0f;
+    public const float ZERO_CELCIUS_KELVIN = 273.15f;
+    public const float ONE_KELVIN = ZERO_CELCIUS_KELVIN + ONE_CELCIUS;
+    public const float FIVE_KELVIN = ZERO_CELCIUS_KELVIN + FIVE_CELCIUS;
+
+    public const float TEN_KELVIN = ZERO_CELCIUS_KELVIN + TEN_CELCIUS;
+    public const float FIFTEEN_KELVIN = ZERO_CELCIUS_KELVIN + FIFTEEN_CELCIUS;
+
+    public const float TWENTY_KELVIN = ZERO_CELCIUS_KELVIN + TWENTY_CELCIUS;
+    public const float TWENTY_FIVE_KELVIN = ZERO_CELCIUS_KELVIN + TWENTY_FIVE_CELCIUS;
+
+    public const float THIRTY_KELVIN = ZERO_CELCIUS_KELVIN + THIRTY_CELCIUS;
+    public const float THIRTY_FIVE_KELVIN = ZERO_CELCIUS_KELVIN + THIRTY_FIVE_CELCIUS;
+
+    public const float FOURTY_KELVIN = ZERO_CELCIUS_KELVIN + FOURTY_CELCIUS;
+    public const float FOURTY_FIVE_KELVIN = ZERO_CELCIUS_KELVIN + FOURTY_FIVE_CELCIUS;
+
+    public const float FIFTY_KELVIN = ZERO_CELCIUS_KELVIN + FIFTY_CELCIUS;
+
+    public const float MINIMUM_SAFE_KELVIN = ZERO_CELCIUS_KELVIN;
+    public const float MAXIMUM_SAFE_KELVIN = FIFTY_KELVIN;
+
+    public const float MINIMUM_KELVIN = ZERO_CELCIUS_KELVIN + MINIMUM_CELCIUS;
+    public const float MAXIMUM_KELVIN = ZERO_CELCIUS_KELVIN + MAXIMUM_CELCIUS;
+
+    // PRESSURE: KPA
+    public const float ONE_ATMOSPHERE_PRESSURE_KPA = 101.325f;
+    public const float TWO_ATMOSPHERE_PRESSURE_KPA = ONE_ATMOSPHERE_PRESSURE_KPA * 2f;
+    public const float THREE_ATMOSPHERE_PRESSURE_KPA = ONE_ATMOSPHERE_PRESSURE_KPA * 3f;
+    public const float FOUR_ATMOSPHERE_PRESSURE_KPA = ONE_ATMOSPHERE_PRESSURE_KPA * 4f;
+    public const float FIVE_ATMOSPHERE_PRESSURE_KPA = ONE_ATMOSPHERE_PRESSURE_KPA * 5f;
+    public const float SIX_ATMOSPHERE_PRESSURE_KPA = ONE_ATMOSPHERE_PRESSURE_KPA * 6f;
+
+    public const float MINIMUM_SAFE_PRESSURE_KPA = 20f;
+    public const float MAXIMUM_SAFE_PRESSURE_KPA = SIX_ATMOSPHERE_PRESSURE_KPA;
+
+    public const float MINIMUM_PRESSURE_KPA = 0f;
+    public const float MAXIMUM_PRESSURE_KPA = 1000000f;
+  }
+}

--- a/LaunchPadBooster/Utils/Extensions.cs
+++ b/LaunchPadBooster/Utils/Extensions.cs
@@ -1,0 +1,133 @@
+﻿using Assets.Scripts.Atmospherics;
+using CharacterCustomisation;
+using HarmonyLib;
+using System.Reflection.Emit;
+
+namespace LaunchPadBooster.Utils
+{
+  public static class StringExtensions
+  {
+    public static string ToStringPrefix(this double value, string unit = "", string color = "") => value.ToStringPrefix(unit, color);
+    public static string ToStringPrefix(this float value, string unit = "", string color = "") => value.ToStringPrefix(unit, color);
+    public static string ToStringPrefix(this PressurekPa value, string unit = "", string color = "") => value.ToFloat().ToStringPrefix(unit, color);
+    public static string ToStringPrefix(this TemperatureKelvin value, string unit = "", string color = "") => value.ToFloat().ToStringPrefix(unit, color);
+    public static string ToStringPrefix(this VolumeLitres value, string unit = "", string color = "") => value.ToFloat().ToStringPrefix(unit, color);
+    public static string ToStringPrefix(this MoleQuantity value, string unit = "", string color = "") => value.ToFloat().ToStringPrefix(unit, color);
+  }
+
+  public static class CodeInstructionExtensions
+  {
+    public static bool OpcodeIs(this CodeInstruction instruction, OpCode opcode) => instruction?.opcode == opcode;
+  }
+
+  public static class UnitExtensions
+  {
+    public static bool IsKelvinNil(this float value) => value <= Constants.MINIMUM_KELVIN;
+    public static bool IsKelvinNil(this TemperatureKelvin value) => value.ToFloat().IsKelvinNil();
+
+    public static bool IsCelciusNil(this float value) => value <= Constants.MINIMUM_CELCIUS;
+    public static bool IsCelciusNil(this TemperatureKelvin value) => value.ToFloat().IsCelciusNil();
+
+    public static float CelciusToKelvin(this float celcius) => celcius + Constants.ZERO_CELCIUS_KELVIN;
+    public static float CelciusToFahrenheit(this float celcius) => (celcius * 1.8f) + 32f;
+
+    public static float KelvinToCelcius(this float kelvin) => kelvin - Constants.ZERO_CELCIUS_KELVIN;
+    public static float KelvinToCelcius(this TemperatureKelvin kelvin) => kelvin.ToFloat().KelvinToCelcius();
+    public static float KelvinToFahrenheit(this float kelvin) => (kelvin.KelvinToCelcius() * 1.8f) + 32f;
+    public static float KelvinToFahrenheit(this TemperatureKelvin kelvin) => kelvin.ToFloat().KelvinToFahrenheit();
+
+    public static float FahrenheitToCelcius(this float fahrenheit) => (fahrenheit - 32f) * 1.8f;
+    public static float FahrenheitToKelvin(this float fahrenheit) => FahrenheitToCelcius(fahrenheit).CelciusToFahrenheit();
+
+    public static float MicroPascalToMilliPascal(this float uPa) => uPa * 1000f;
+    public static float MicroPascalToPascal(this float uPa) => uPa.MicroPascalToMilliPascal() * 1000f;
+    public static float MicroPascalToKiloPascal(this float uPa) => uPa.MicroPascalToPascal() * 1000f;
+    public static float MicroPascalToMegaPascal(this float uPa) => uPa.MicroPascalToKiloPascal() * 1000f;
+    public static float MicroPascalToGigaPascal(this float uPa) => uPa.MicroPascalToMegaPascal() * 1000f;
+
+    public static float MilliPascalToMicroPascal(this float mPa) => mPa / 1000f;
+    public static float MilliPascalToPascal(this float mPa) => mPa * 1000f;
+    public static float MilliPascalToKiloPascal(this float mPa) => mPa.MilliPascalToPascal() * 1000f;
+    public static float MilliPascalToMegaPascal(this float mPa) => mPa.MilliPascalToKiloPascal() * 1000f;
+    public static float MilliPascalToGigaPascal(this float mPa) => mPa.MilliPascalToGigaPascal() * 1000f;
+
+    public static float PascalToMicoPascal(this float Pa) => Pa.PascalToMilliPascal() * 1000f;
+    public static float PascalToMilliPascal(this float Pa) => Pa * 1000f;
+    public static float PascalToKiloPascal(this float Pa) => Pa / 1000f;
+    public static float PascalToMegaPascal(this float Pa) => Pa.PascalToKiloPascal() / 1000f;
+    public static float PascalToGigaPascal(this float Pa) => Pa.PascalToMegaPascal() / 1000f;
+
+    public static float KiloPascalToMicroPascal(this float kPa) => kPa.KiloPascalToMilliPascal() * 1000f;
+    public static float KiloPascalToMicroPascal(this PressurekPa kPa) => kPa.ToFloat().KiloPascalToMilliPascal() * 1000f;
+    public static float KiloPascalToMilliPascal(this float kPa) => kPa.KiloPascalToPascal() * 1000f;
+    public static float KiloPascalToMilliPascal(this PressurekPa kPa) => kPa.ToFloat().KiloPascalToPascal() * 1000f;
+    public static float KiloPascalToPascal(this float kPa) => kPa * 1000f;
+    public static float KiloPascalToPascal(this PressurekPa kPa) => kPa.ToFloat() * 1000f;
+    public static float KiloPascalToMegaPascal(this float kPa) => kPa / 1000f;
+    public static float KiloPascalToMegaPascal(this PressurekPa kPa) => kPa.ToFloat() / 1000f;
+    public static float KiloPascalToGigaPascal(this float kPa) => kPa.KiloPascalToMegaPascal() / 1000f;
+    public static float KiloPascalToGigaPascal(this PressurekPa kPa) => kPa.ToFloat().KiloPascalToMegaPascal() / 1000f;
+
+    public static float MegaPascalToMicroPascal(this float MPa) => MPa.MegaPascalToMilliPascal() / 1000f;
+    public static float MegaPascalToMilliPascal(this float MPa) => MPa.MegaPascalToPascal() / 1000f;
+    public static float MegaPascalToPascal(this float MPa) => MPa.MegaPascalToKiloPascal() / 1000f;
+    public static float MegaPascalToKiloPascal(this float MPa) => MPa / 1000f;
+    public static float MegaPascalToGigaPascal(this float MPa) => MPa * 1000f;
+
+    public static float GigaPascalToMicroPascal(this float GPa) => GPa.GigaPascalToMilliPascal() / 1000f;
+    public static float GigaPascalToMilliPascal(this float GPa) => GPa.GigaPascalToPascal() / 1000f;
+    public static float GigaPascalToPascal(this float GPa) => GPa.GigaPascalToKiloPascal() / 1000f;
+    public static float GigaPascalToKiloPascal(this float GPa) => GPa.GigaPascalToMegaPascal() / 1000f;
+    public static float GigaPascalToMegaPascal(this float GPa) => GPa / 1000f;
+
+    public static float MicroPascalToPsi(this float uPa) => uPa.MicroPascalToKiloPascal() / 6.89476f;
+    public static float MilliPascalToPsi(this float mPa) => mPa.MilliPascalToKiloPascal() / 6.89476f;
+    public static float PascalToPsi(this float Pa) => Pa.PascalToKiloPascal() / 6.89476f;
+    public static float KiloPascalToPsi(this float kPa) => kPa / 6.89476f;
+    public static float KiloPascalToPsi(this PressurekPa kPa) => kPa.ToFloat() / 6.89476f;
+    public static float MegaPascalToPsi(this float MPa) => MPa.MegaPascalToKiloPascal() / 6.89476f;
+    public static float GigaPascalToPsi(this float GPa) => GPa.GigaPascalToKiloPascal() / 6.89476f;
+
+    public static float PsiToMicroPascal(this float Psi) => Psi.PsiToMilliPascal() * 1000;
+    public static float PsiToMilliPascal(this float Psi) => Psi.PsiToPascal() * 1000;
+    public static float PsiToPascal(this float Psi) => Psi.PsiToKiloPascal() * 1000;
+    public static float PsiToKiloPascal(this float Psi) => Psi * 6.89476f;
+    public static float PsiToMegaPascal(this float Psi) => Psi.PsiToKiloPascal() / 1000;
+    public static float PsiToGigaPascal(this float Psi) => Psi.PsiToMegaPascal() / 1000;
+
+    public static float BarToMicroPascal(this float Bar) => Bar.BarToMilliPascal() * 100f;
+    public static float BarToMilliPascal(this float Bar) => Bar.BarToPascal() * 100f;
+    public static float BarToPascal(this float Bar) => Bar.BarToKiloPascal() * 100f;
+    public static float BarToKiloPascal(this float Bar) => Bar * 100f;
+    public static float BarToMegaPascal(this float Bar) => Bar / 10f;
+    public static float BarToGigaPascal(this float Bar) => Bar.BarToMegaPascal() / 1000f;
+
+    public static float MicroPascalToBar(this float uPa) => uPa.MicroPascalToKiloPascal() / 100f;
+    public static float MilliPascalToBar(this float mPa) => mPa.MilliPascalToKiloPascal() / 100f;
+    public static float PascalToBar(this float Pa) => Pa.PascalToKiloPascal() / 100f;
+    public static float KiloPascalToBar(this float kPa) => kPa / 100f;
+    public static float KiloPascalToBar(this PressurekPa kPa) => kPa.ToFloat().KiloPascalToBar();
+    public static float MegaPascalToBar(this float MPa) => MPa.MegaPascalToKiloPascal() / 100f;
+    public static float GigaPascalToBar(this float GPa) => GPa.GigaPascalToKiloPascal() / 100f;
+
+    public static float LiterToImperialGallon(this float liter) => liter / 4.546f;
+    public static float LiterToUSGallon(this float liter) => liter * 1.057f;
+    public static float LiterToCubicInch(this float liter) => liter * 61.024f;
+
+    public static float LiterToImperialGallon(this VolumeLitres liter) => liter.ToFloat().LiterToImperialGallon();
+    public static float LiterToUSGallon(this VolumeLitres liter) => liter.ToFloat().LiterToUSGallon();
+    public static float LiterToCubicInch(this VolumeLitres liter) => liter.ToFloat().LiterToCubicInch();
+
+    public static float PartialMoles(this Atmosphere atmosphere, Chemistry.GasType gasType) => atmosphere.TotalMoles.ToFloat() * atmosphere.GetGasTypeRatio(gasType);
+  }
+
+  public static class SpeciesExtensions
+  {
+    public static Chemistry.GasType GetAirType(this SpeciesClass species) => species switch
+    {
+      SpeciesClass.Human => Chemistry.GasType.Oxygen,
+      SpeciesClass.Zrilian => Chemistry.GasType.Volatiles,
+      _ => Chemistry.GasType.Undefined,
+    };
+  }
+}


### PR DESCRIPTION
Mod events will be used to have feedback on things happening in the game, for instance when a scene is loaded/unloaded, when a main menu page is opened (new game, load game)

Mod creators will use Mod.OnEvent to connect to events being sent

an example usage

```csharp
using System.Collections.Generic;
using LaunchPadBooster;
using LaunchPadBooster.Events;
using UnityEngine;

public class MyMod : MonoBehaviour
{
  // mod registration
  public static readonly Mod MOD = new("MyMod", "0.1.0");

  // default entry point
  public void OnLoaded(List<GameObject> prefabs)
  {
    MOD.OnEvent += this.MOD_OnEvent;
  }

  private void MOD_OnEvent(ModEvent modEvent)
  {
    if (modEvent is SplashSceneUnloadEvent)
    {
      // do something when splash scene is unloaded
    }

    if (modEvent is NewGameMenuOpenedEvent)
    {
      // do something when new game menu is opened
    }

    if (modEvent is SceneUnloadEvent)
    {
      // do something when any scene is unloaded
    }
  }
}
```